### PR TITLE
feat: implement phoenixd-compatible authentication for fmcd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1360,12 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1989,16 +2008,18 @@ dependencies = [
 
 [[package]]
 name = "fmcd"
-version = "0.4.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-utility",
  "axum",
  "axum-macros",
+ "base64 0.21.7",
  "bip39",
  "bitcoin",
  "chrono",
  "clap",
+ "console",
  "dotenv",
  "fedimint-api-client",
  "fedimint-bip39",
@@ -2013,6 +2034,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
+ "hmac",
  "itertools 0.12.1",
  "lazy_static",
  "lnurl-rs",
@@ -2022,9 +2044,11 @@ dependencies = [
  "reqwest 0.12.23",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "time",
  "tokio",
+ "toml",
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",
@@ -5527,6 +5551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6225,10 +6258,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -6237,9 +6285,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.10.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -6458,6 +6515,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,21 @@
 [package]
 name = "fmcd"
 description = "A fedimint client daemon for server side applications to hold, use, and manage Bitcoin"
-version = "0.4.0"
+version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/minmoto/fmcd"
 keywords = ["fedimint", "bitcoin", "lightning", "ecash"]
 license = "MIT"
 readme = "README.md"
 authors = ["Minmo Developers"]
+
+[lib]
+name = "fmcd"
+path = "src/lib.rs"
+
+[[bin]]
+name = "fmcd"
+path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.75"
@@ -34,7 +42,6 @@ time = { version = "0.3.25", features = ["formatting"] }
 chrono = "0.4.31"
 futures-util = "0.3.30"
 clap = { version = "3", features = ["derive", "env"] }
-# Dependencies from multimint
 fedimint-api-client = "0.8.0"
 fedimint-client = "0.8.0"
 fedimint-core = "0.8.0"
@@ -48,10 +55,15 @@ fedimint-derive-secret = "0.8.0"
 rand = "0.8.5"
 bip39 = "2.1.0"
 hex = "0.4.3"
+base64 = "0.21"
+hmac = "0.12"
+sha2 = "0.10"
+toml = "0.8"
 
 futures = "0.3"
 metrics = { version = "0.23", default-features = false }
 metrics-exporter-prometheus = { version = "0.15.3", default-features = false }
+console = "0.15"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/src/auth/basic.rs
+++ b/src/auth/basic.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::Response;
+use base64::Engine;
+
+#[derive(Clone)]
+pub struct BasicAuth {
+    username: String,
+    password: String,
+    enabled: bool,
+}
+
+impl BasicAuth {
+    /// Create new BasicAuth instance following phoenixd model
+    /// Uses fixed username "fmcd" and optional password
+    pub fn new(password: Option<String>) -> Self {
+        Self {
+            username: "fmcd".to_string(), // Fixed username like phoenixd
+            password: password.clone().unwrap_or_default(),
+            enabled: password.is_some(),
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn verify(&self, auth_header: &str) -> bool {
+        if !self.enabled {
+            return true;
+        }
+
+        if !auth_header.starts_with("Basic ") {
+            return false;
+        }
+
+        let credentials = &auth_header[6..];
+        match base64::engine::general_purpose::STANDARD.decode(credentials) {
+            Ok(decoded) => {
+                let decoded_str = String::from_utf8_lossy(&decoded);
+                decoded_str == format!("{}:{}", self.username, self.password)
+            }
+            Err(_) => false,
+        }
+    }
+}
+
+pub async fn basic_auth_middleware(
+    auth: Arc<BasicAuth>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    // If authentication is disabled, pass through
+    if !auth.enabled {
+        return Ok(next.run(request).await);
+    }
+
+    let auth_header = request
+        .headers()
+        .get("Authorization")
+        .and_then(|header| header.to_str().ok());
+
+    match auth_header {
+        Some(header) if auth.verify(header) => Ok(next.run(request).await),
+        _ => {
+            let response = Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .header("WWW-Authenticate", "Basic realm=\"fmcd\"")
+                .body(Body::from("Unauthorized"))
+                .unwrap_or_else(|_| {
+                    // Fallback to a minimal response if building fails
+                    Response::new(Body::from("Unauthorized"))
+                });
+            Ok(response)
+        }
+    }
+}

--- a/src/auth/hmac.rs
+++ b/src/auth/hmac.rs
@@ -1,0 +1,90 @@
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Clone)]
+pub struct WebSocketAuth {
+    secret: Vec<u8>,
+    enabled: bool,
+}
+
+impl WebSocketAuth {
+    /// Create new WebSocketAuth instance following phoenixd model
+    /// Uses the same password as HTTP Basic Auth for simplicity
+    pub fn new(password: Option<String>) -> Self {
+        Self {
+            secret: password.clone().unwrap_or_default().as_bytes().to_vec(),
+            enabled: password.is_some(),
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Create HMAC-SHA256 signature for a message with timestamp
+    /// Following phoenixd's simple approach without replay protection
+    pub fn create_signature(&self, message: &str, timestamp: i64) -> Result<String, String> {
+        if !self.enabled {
+            return Ok(String::new());
+        }
+
+        let mut mac = HmacSha256::new_from_slice(&self.secret)
+            .map_err(|e| format!("Failed to create HMAC: {}", e))?;
+
+        let payload = format!("{}{}", timestamp, message);
+        mac.update(payload.as_bytes());
+
+        Ok(hex::encode(mac.finalize().into_bytes()))
+    }
+
+    /// Verify HMAC signature for a message with timestamp
+    /// No replay protection - just signature verification like phoenixd
+    pub fn verify_signature(&self, message: &str, timestamp: i64, signature: &str) -> bool {
+        if !self.enabled {
+            return true;
+        }
+
+        match self.create_signature(message, timestamp) {
+            Ok(expected) => expected == signature,
+            Err(_) => false,
+        }
+    }
+}
+
+/// WebSocket message format with HMAC authentication
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AuthenticatedMessage {
+    pub timestamp: i64,
+    pub signature: String,
+    pub payload: serde_json::Value,
+}
+
+impl AuthenticatedMessage {
+    /// Create new authenticated message
+    pub fn new(payload: serde_json::Value, auth: &WebSocketAuth) -> Result<Self, String> {
+        let timestamp = chrono::Utc::now().timestamp();
+        let payload_str = serde_json::to_string(&payload)
+            .map_err(|e| format!("Failed to serialize payload: {}", e))?;
+
+        let signature = auth.create_signature(&payload_str, timestamp)?;
+
+        Ok(Self {
+            timestamp,
+            signature,
+            payload,
+        })
+    }
+
+    /// Verify the message signature
+    pub fn verify(&self, auth: &WebSocketAuth) -> bool {
+        let payload_str = match serde_json::to_string(&self.payload) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+
+        auth.verify_signature(&payload_str, self.timestamp, &self.signature)
+    }
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,0 +1,5 @@
+pub mod basic;
+pub mod hmac;
+
+pub use basic::{basic_auth_middleware, BasicAuth};
+pub use hmac::{AuthenticatedMessage, WebSocketAuth};

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,173 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+
+/// Configuration structure following phoenixd model
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Config {
+    /// HTTP server bind IP address
+    #[serde(rename = "http-bind-ip", default = "default_bind_ip")]
+    pub http_bind_ip: String,
+
+    /// HTTP server bind port
+    #[serde(rename = "http-bind-port", default = "default_bind_port")]
+    pub http_bind_port: u16,
+
+    /// HTTP Basic Auth password (plain text, optional)
+    /// When None, authentication is disabled
+    #[serde(rename = "http-password")]
+    pub http_password: Option<String>,
+
+    /// WebSocket enabled flag
+    #[serde(rename = "websocket-enabled", default = "default_websocket_enabled")]
+    pub websocket_enabled: bool,
+
+    /// WebSocket port (if different from HTTP)
+    #[serde(rename = "websocket-port")]
+    pub websocket_port: Option<u16>,
+
+    /// Data directory for the daemon
+    #[serde(rename = "data-dir")]
+    pub data_dir: Option<PathBuf>,
+
+    /// Federation invite code
+    #[serde(rename = "invite-code")]
+    pub invite_code: Option<String>,
+
+    /// Database path
+    #[serde(rename = "db-path")]
+    pub db_path: Option<PathBuf>,
+
+    /// Manual secret for additional security
+    #[serde(rename = "manual-secret")]
+    pub manual_secret: Option<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            http_bind_ip: default_bind_ip(),
+            http_bind_port: default_bind_port(),
+            http_password: None,
+            websocket_enabled: default_websocket_enabled(),
+            websocket_port: None,
+            data_dir: None,
+            invite_code: None,
+            db_path: None,
+            manual_secret: None,
+        }
+    }
+}
+
+impl Config {
+    /// Load configuration from TOML file
+    pub fn load_from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+
+        // Ensure parent directory exists (important for Docker volumes)
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let contents = std::fs::read_to_string(path)?;
+        let config: Config = toml::from_str(&contents)?;
+        Ok(config)
+    }
+
+    /// Save configuration to TOML file
+    pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        let path = path.as_ref();
+
+        // Ensure parent directory exists (important for Docker volumes)
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let contents = toml::to_string_pretty(self)?;
+        std::fs::write(path, contents)?;
+        Ok(())
+    }
+
+    /// Get the complete HTTP server address
+    pub fn http_address(&self) -> String {
+        format!("{}:{}", self.http_bind_ip, self.http_bind_port)
+    }
+
+    /// Get the WebSocket address (same as HTTP if not specified)
+    pub fn websocket_address(&self) -> String {
+        let port = self.websocket_port.unwrap_or(self.http_bind_port);
+        format!("{}:{}", self.http_bind_ip, port)
+    }
+
+    /// Check if authentication is enabled
+    pub fn is_auth_enabled(&self) -> bool {
+        self.http_password.is_some()
+    }
+
+    /// Get the authentication password
+    pub fn auth_password(&self) -> Option<&str> {
+        self.http_password.as_deref()
+    }
+
+    /// Generate a secure random 32-byte hex password (matching phoenixd's
+    /// behavior)
+    pub fn generate_password() -> String {
+        let mut bytes = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut bytes);
+        hex::encode(bytes)
+    }
+
+    /// Load or create configuration file with automatic password generation
+    pub fn load_or_create<P: AsRef<Path>>(path: P) -> Result<(Self, bool)> {
+        let path = path.as_ref();
+        let mut password_generated = false;
+
+        // Ensure parent directory exists (important for Docker volumes)
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let mut config = if path.exists() {
+            Self::load_from_file(path)?
+        } else {
+            let config = Self::default();
+            config.save_to_file(path)?;
+            config
+        };
+
+        // Check if we need to generate and append password
+        if config.http_password.is_none() {
+            let generated_password = Self::generate_password();
+
+            // Append to config file
+            let append_content = format!("\nhttp-password = \"{}\"\n", generated_password);
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)?
+                .write_all(append_content.as_bytes())?;
+
+            // Update in-memory config
+            config.http_password = Some(generated_password);
+            password_generated = true;
+        }
+
+        Ok((config, password_generated))
+    }
+}
+
+// Default value functions
+fn default_bind_ip() -> String {
+    "127.0.0.1".to_string()
+}
+
+fn default_bind_port() -> u16 {
+    7070
+}
+
+fn default_websocket_enabled() -> bool {
+    true
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,8 @@
+// Library exports for testing and external use
+pub mod auth;
+pub mod config;
+pub mod error;
+pub mod multimint;
+pub mod router;
+pub mod state;
+pub mod utils;

--- a/tests/auth_tests.rs
+++ b/tests/auth_tests.rs
@@ -1,0 +1,43 @@
+use fmcd::auth::hmac::{AuthenticatedMessage, WebSocketAuth};
+use serde_json::json;
+
+#[test]
+fn test_websocket_auth_disabled() {
+    let auth = WebSocketAuth::new(None);
+    assert!(!auth.is_enabled());
+
+    // Should always return true when disabled
+    assert!(auth.verify_signature("test", 1234567890, "invalid"));
+}
+
+#[test]
+fn test_websocket_auth_enabled() {
+    let auth = WebSocketAuth::new(Some("testpassword".to_string()));
+    assert!(auth.is_enabled());
+
+    let timestamp = 1234567890;
+    let message = "test message";
+
+    let signature = auth.create_signature(message, timestamp).unwrap();
+    assert!(auth.verify_signature(message, timestamp, &signature));
+
+    // Wrong signature should fail
+    assert!(!auth.verify_signature(message, timestamp, "wrongsig"));
+
+    // Wrong timestamp should fail
+    assert!(!auth.verify_signature(message, timestamp + 1, &signature));
+}
+
+#[test]
+fn test_authenticated_message() {
+    let auth = WebSocketAuth::new(Some("testpassword".to_string()));
+    let payload = json!({"type": "test", "data": "hello"});
+
+    let msg = AuthenticatedMessage::new(payload.clone(), &auth).unwrap();
+    assert!(msg.verify(&auth));
+
+    // Tampered payload should fail verification
+    let mut tampered_msg = msg.clone();
+    tampered_msg.payload = json!({"type": "tampered"});
+    assert!(!tampered_msg.verify(&auth));
+}

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,0 +1,130 @@
+use fmcd::config::Config;
+use tempfile::tempdir;
+
+#[test]
+fn test_default_config() {
+    let config = Config::default();
+    assert_eq!(config.http_bind_ip, "127.0.0.1");
+    assert_eq!(config.http_bind_port, 7070);
+    assert!(config.http_password.is_none());
+    assert!(!config.is_auth_enabled());
+}
+
+#[test]
+fn test_config_with_auth() {
+    let mut config = Config::default();
+    config.http_password = Some("testpassword".to_string());
+    assert!(config.is_auth_enabled());
+    assert_eq!(config.auth_password(), Some("testpassword"));
+}
+
+#[test]
+fn test_config_addresses() {
+    let config = Config::default();
+    assert_eq!(config.http_address(), "127.0.0.1:7070");
+    assert_eq!(config.websocket_address(), "127.0.0.1:7070");
+
+    let mut config_with_ws_port = Config::default();
+    config_with_ws_port.websocket_port = Some(9741);
+    assert_eq!(config_with_ws_port.websocket_address(), "127.0.0.1:9741");
+}
+
+#[test]
+fn test_config_save_load() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("test.toml");
+
+    let mut original_config = Config::default();
+    original_config.http_password = Some("testpass".to_string());
+    original_config.http_bind_port = 8080;
+
+    // Save config
+    original_config.save_to_file(&config_path).unwrap();
+
+    // Load config
+    let loaded_config = Config::load_from_file(&config_path).unwrap();
+
+    assert_eq!(loaded_config.http_password, Some("testpass".to_string()));
+    assert_eq!(loaded_config.http_bind_port, 8080);
+}
+
+#[test]
+fn test_generate_password() {
+    let password1 = Config::generate_password();
+    let password2 = Config::generate_password();
+
+    // Passwords should be different
+    assert_ne!(password1, password2);
+
+    // Should be 64 hex characters (32 bytes * 2 hex chars per byte)
+    assert_eq!(password1.len(), 64);
+    assert_eq!(password2.len(), 64);
+
+    // Should be valid hex
+    assert!(password1.chars().all(|c| c.is_ascii_hexdigit()));
+    assert!(password2.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn test_load_or_create_new_file() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("new_config.toml");
+
+    // File doesn't exist
+    assert!(!config_path.exists());
+
+    // Load or create should create file and generate password
+    let (config, password_generated) = Config::load_or_create(&config_path).unwrap();
+
+    assert!(config_path.exists());
+    assert!(password_generated);
+    assert!(config.http_password.is_some());
+
+    let password = config.http_password.unwrap();
+    assert_eq!(password.len(), 64);
+    assert!(password.chars().all(|c| c.is_ascii_hexdigit()));
+
+    // Verify the file contains the password
+    let file_contents = std::fs::read_to_string(&config_path).unwrap();
+    assert!(file_contents.contains(&format!("http-password = \"{}\"", password)));
+}
+
+#[test]
+fn test_load_or_create_existing_file_with_password() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("existing_config.toml");
+
+    // Create a config with password
+    let mut original_config = Config::default();
+    original_config.http_password = Some("existingpass".to_string());
+    original_config.save_to_file(&config_path).unwrap();
+
+    // Load or create should not generate new password
+    let (config, password_generated) = Config::load_or_create(&config_path).unwrap();
+
+    assert!(!password_generated);
+    assert_eq!(config.http_password, Some("existingpass".to_string()));
+}
+
+#[test]
+fn test_load_or_create_existing_file_without_password() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("config_no_pass.toml");
+
+    // Create a config without password
+    let original_config = Config::default();
+    original_config.save_to_file(&config_path).unwrap();
+
+    // Load or create should generate password
+    let (config, password_generated) = Config::load_or_create(&config_path).unwrap();
+
+    assert!(password_generated);
+    assert!(config.http_password.is_some());
+
+    let password = config.http_password.unwrap();
+    assert_eq!(password.len(), 64);
+
+    // Verify the file was updated with the password
+    let file_contents = std::fs::read_to_string(&config_path).unwrap();
+    assert!(file_contents.contains(&format!("http-password = \"{}\"", password)));
+}


### PR DESCRIPTION
- Add HTTP Basic Authentication with fixed username 'fmcd'
- Implement HMAC-SHA256 authentication for WebSocket
- Auto-generate 64-character hex password on first run
- Store configuration in TOML file with Docker volume support
- Simplify architecture by merging metrics endpoint to main port
- Update README with authentication documentation and Docker Compose example
- Fix linting issues in test code